### PR TITLE
Added nuspec file

### DIFF
--- a/ChartMogul/ChartMogul.API.nuspec
+++ b/ChartMogul/ChartMogul.API.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <!-- Required elements-->
+    <id>OConnors.ChartMogul</id>
+    <version>0.00</version>
+    <description>A .NET client for the ChartMogul REST API.</description>
+    <copyright>Copyright ©2017 O'Connor's</copyright>
+    <authors>John Craft</authors>
+
+    <dependencies>
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
+      <dependency id="StructureMap" version="4.4.2" />
+    </dependencies>  
+  </metadata>
+  <!-- Optional 'files' node -->
+</package>


### PR DESCRIPTION
The nuspec file gives us more control over how the package is created. In this case, the nuspec file is used to define other NuGet dependencies.